### PR TITLE
server.go: fix out of range when parsing UInt64

### DIFF
--- a/server.go
+++ b/server.go
@@ -85,9 +85,9 @@ func (srv *QuicSpdyServer) ListenAndServe() error {
 			case 0xC:
 				connId = binary.LittleEndian.Uint64(buf[1:9])
 			case 0x8:
-				connId = binary.LittleEndian.Uint64(buf[1:5])
+				connId = uint64(binary.LittleEndian.Uint32(buf[1:5]))
 			case 0x4:
-				connId = binary.LittleEndian.Uint64(buf[1:2])
+				connId = uint64(binary.LittleEndian.Uint16(buf[1:2]))
 			default:
 				connId = 0
 			}


### PR DESCRIPTION
[Reading 8 bytes](https://github.com/golang/go/blob/master/src/encoding/binary/binary.go#L69) out of 2 byte buffer will eventually crash here. 
P.S. What are those magical numbers here?
