### PR TITLE
Fix panic: index out of range when packet length is zero

### DIFF
--- a/server.go
+++ b/server.go
@@ -116,6 +116,10 @@ func (srv *QuicSpdyServer) ListenAndServe() error {
 				// TODO(serialx): Don't panic and keep calm...
 				panic(err)
 			}
+			// Ignore zero length packet
+			if n == 0 {
+				continue
+			}
 
 			var connId uint64 = 0
 			var parsed bool = false


### PR DESCRIPTION
When reading a packet of length zero, program panic with `runtime error: index out of range` because the code always accesses first byte of buffer.
(https://github.com/devsisters/goquic/blob/master/dispatcher.go#L51)
Fixed it.